### PR TITLE
Убрать ограничение по времени в waCliController

### DIFF
--- a/wa-system/controller/waCliController.class.php
+++ b/wa-system/controller/waCliController.class.php
@@ -14,6 +14,12 @@
  */
 class waCliController extends waController
 {
+    public function preExecute()
+	{
+		parent::preExecute();
+        @set_time_limit(0);
+	}
+    
     public function execute()
     {
 


### PR DESCRIPTION
При запуске, например "cli.php shop searchIndex" вылетает по таймауту.
