### PR TITLE
Update waAPIController.class.php

### DIFF
--- a/wa-system/api/waAPIController.class.php
+++ b/wa-system/api/waAPIController.class.php
@@ -54,6 +54,8 @@ class waAPIController
             $parts = explode('/', $request_url);
             if (count($parts) == 3) {
                 $this->execute($parts[1], $parts[2]);
+            } elseif (count($parts) == 4) {
+                $this->execute($parts[1], $parts[2].".".$parts[3]);
             } elseif (count($parts) == 2 && strpos($parts[1], '.') !== false) {
                 $parts = explode('.', $parts[1], 2);
                 $this->execute($parts[0], $parts[1]);


### PR DESCRIPTION
When you need to call method of plug-in, you turn to the address like:
[domain]/api.php/[app]/[plugin].[method] 
but however, some third-party clients should refer to a specific endpart URL, for example /cart.

This commit allows such a request method like:
[domain]/api.php/[app]/[plugin]/[method]
