### PR TITLE
Added more configuration options to pagination links generator

### DIFF
--- a/wa-system/vendors/smarty-plugins/function.wa_pagination.php
+++ b/wa-system/vendors/smarty-plugins/function.wa_pagination.php
@@ -1,54 +1,160 @@
 <?php
-
+/**
+ * Smarty plugin to generate a list of pagination links
+ * 
+ * @param array $params Array of parameters. Possible values are:
+ *  'total' - Total pages. Default 1
+ *  'nb' - how many numbers to include on either side of the current page. Default 1
+ *  'prev' - Title for 'Previous' link. Default is left arrow
+ *  'next' - Title for 'Next' link. Default is right arrow
+ *  'url' - URL. Default empty (current)
+ *  'attrs' - array of attributes of ul tag. Empty by default
+ *  'page' - Current page number. Set to 0 to extract automatically from GET parameter 'page'
+ *  'hide_disabled_li' - Show/hide disabled list items for prev/next links at first and last page
+ *  'attrs_disabled_li' - Attributes of disabled list tag if it shown
+ *  'attrs_link' - Link tag attributes
+ *  'attrs_li' - Normal list tag attributes
+ *  'attrs_current_li'
+ * @param type $smarty
+ * @return string
+ * 
+ * @author Serge Rodovnichenko <sergerod@gmail.com>
+ */
 function smarty_function_wa_pagination($params, &$smarty)
 {
+    $defaults = array(
+        'total' => 1,
+        'nb' => 1,
+        'prev' => '&larr;',
+        'next' => '&rarr',
+        'url' => '',
+        'attrs' => array(),
+        'page' => 0,
+        'hide_disabled_li' => TRUE,
+        'attrs_disabled_li' => array(),
+        'attrs_link' => array('class'=>'inline-link'),
+        'attrs_li' => array(),
+        'attrs_current_li' => array()
+    );
 
-    $total = $params['total'];
-    $page = isset($params['page']) ? $params['page'] : waRequest::get('page', 1);
+    $params = array_merge($defaults, $params);
+
+    extract($params);
+    
+    $html = '';
+    
+    if ($total < 2) {
+        return $html;
+    }
+
+    $page = $page ?: waRequest::get('page', 1);
     if ($page < 1) {
         $page = 1;
     }
-    $nb = isset($params['nb']) ? $params['nb'] : 1;
-    $prev = isset($params['prev']) ? $params['prev'] : '←';
-    $next = isset($params['next']) ? $params['next'] : '→';
 
-    if ($total < 2) {
-        return '';
-    }
-
-    $url = isset($params['url']) ? $params['url'] : '';
-
-    $html = '<ul';
-    $attrs = isset($params['attrs']) ? $params['attrs'] : array();
+    $html .= '<ul';
     foreach ($attrs as  $k => $v) {
         $html .= ' '.$k.'="'.$v.'"';
     }
     $html .= '>';
+
     $get_params = waRequest::get();
     if (isset($get_params['page'])) {
         unset($get_params['page']);
     }
-    $url_params = http_build_query($get_params);
-    if ($page > 1 && $prev) {
-        $page_url = $url.($url && $page == 2 ? ($url_params ? '?'.$url_params : '') : '?page='.($page - 1).($url_params ? '&'.$url_params : ''));
-        $html .= '<li><a class="inline-link" href="'.$page_url.'">'.$prev.'</a></li>';
+
+    $link_attr_str = '';
+    foreach ($attrs_link as $k => $v) {
+        $link_attr_str .= " $k=\"$v\"";
     }
+
+    $li_disabled_attr_str = '';
+    foreach ($attrs_disabled_li as $k => $v) {
+        $li_disabled_attr_str .= " $k=\"$v\"";
+    }
+
+    $li_attr_str = '';
+    foreach ($attrs_li as $k => $v) {
+        $li_attr_str .= " $k=\"$v\"";
+    }
+
+    $li_current_attr_str = '';
+    foreach ($attrs_current_li as $k => $v) {
+        $li_current_attr_str .= " $k=\"$v\"";
+    }
+
+    /**
+     * Make a 'Prev' link
+     */
+    if(!$hide_disabled_li || ($page > 1 && $prev)) {
+
+        $url_params_array = $get_params;
+
+        // First page doesn't need the 'page' parameter
+        if($page > 2) {
+            $url_params_array['page'] = $page - 1;
+        }
+
+        $url_params = http_build_query($url_params_array);
+
+        $page_url = $url . ($url_params ? "?$url_params" : '');
+
+        if($page > 1) {
+            $html .= "<li{$li_attr_str}><a{$link_attr_str} href=\"{$page_url}\">{$prev}</a></li>";
+        } else {
+            $html .= "<li{$li_disabled_attr_str}>{$prev}</li>";
+        }        
+    }
+
+    /**
+     * Make links to pages
+     */
     $p = 1;
     $n = 1;
     while ($p <= $total) {
         if ($p > $nb && ($total - $p) > $nb && abs($page - $p) > $n && ($p < $page ? ($page - $n - $p > 1) : ($total - $nb > $p))) {
             $p = $p < $page ? $page - $n : $total - $nb + 1;
-            $html .= '<li>...</li>';
+            $html .= "<li$li_disabled_attr_str>&hellip;</li>";
         } else {
-            $page_url = $url.($url && $p == 1 ? ($url_params ? '?'.$url_params : '') : '?page='.$p.($url_params ? '&'.$url_params : ''));
-            $html .= '<li'.($p == $page ? ' class="selected"' : '').'><a href="'.$page_url.'">'.$p.'</a></li>';
+            if($p == 1) {
+                unset($url_params_array['page']);
+            } else {
+                $url_params_array['page'] = $p;
+            }
+
+            $url_params = http_build_query($url_params_array);
+
+            $page_url = $url.($url_params ? "?$url_params" : '');
+            if($p == $page) {
+                $html .= "<li{$li_current_attr_str}><a{$link_attr_str} href=\"$page_url\">$p</a></li>";
+            } else {
+                $html .= "<li{$li_attr_str}><a{$link_attr_str} href=\"$page_url\">$p</a></li>";
+            }
             $p++;
         }
     }
-    if ($page < $total && $next) {
-        $page_url = $url.'?page='.($page + 1).($url_params ? '&'.$url_params : '');
-        $html .= '<li><a class="inline-link" href="'.$page_url.'">'.$next.'</a></li>';
+
+    /**
+     * Make a 'Next' link
+     */
+    if (!$hide_disabled_li || ($page < $total && $next)) {
+
+        $url_params_array['page'] = $page;
+        if($page < $total) {
+            $url_params_array['page']++;
+        }
+        $url_params = http_build_query($url_params_array);
+
+        $page_url = $url.($url_params ? "?$url_params" : '');
+
+        if($total > $page) {
+            $html .= "<li{$li_attr_str}><a{$link_attr_str} href=\"$page_url\">$next</a></li>";
+        } else {
+            $html .= "<li{$li_disabled_attr_str}><a{$link_attr_str} href=\"$page_url\">$next</a></li>";
+        }
     }
+
     $html .= '</ul>';
+
     return $html;
 }


### PR DESCRIPTION
Добавил несколько параметров, чтобы сделать генерацию списка более гибкой. Можно включать показ неактивных ссылок предыдущая/следующая на первой/последней странице, можно добавлять свои атрибуты к ссылками, элементам списка. Например такой вызов сделает список подходящий для Twitter Bootstrap:

``` smarty
{wa_pagination total=$pages_count attrs=['class' => "pagination"] hide_disabled_li=false attrs_disabled_li=['class'=>"disabled"] attrs_current_li=['class'=>"active"]}
```

Со значениями по умолчанию должен работать, как работал
