### PR TITLE
Исправлено получение аргументов в CLI

### DIFF
--- a/wa.php
+++ b/wa.php
@@ -1,13 +1,13 @@
 #!/usr/bin/php
 <?php
 
-if (!isset($argc) || php_sapi_name() !== 'cli') {
+if (PHP_SAPI !== 'cli') {
     die("Run from CLI only!");
 }
 
-require_once(dirname(__FILE__).'/wa-config/SystemConfig.class.php');
+require_once dirname(__FILE__).'/wa-config/SystemConfig.class.php';
 $wa = waSystem::getInstance(null, new SystemConfig('cli'));
-// run cli
-array_splice($argv, 1, 0, 'webasyst');
-$wa->dispatchCli($argv);
-
+// Replace script name
+$_SERVER['argv'][0] = 'webasyst';
+// Run CLI
+$wa->dispatchCli($_SERVER['argv']);


### PR DESCRIPTION
Note: This variable is not available when register_argc_argv is disabled. 
http://php.net/manual/variables.argv

для чего нужен `./cli.php`? он вызывает `./wa-system/cli.php` в котором нет `$_SERVER['argv'][0] = 'webasyst';` и всё та же ошибка с использованием `$argv`.

в `waSystem::dispatchCli($argv)` баги начинаются уже с названия аргумента функции)))  (см. список зарезервированных имен PHP). `$params[$key] = trim(array_shift($argv));` это не сработает если надо передать в качестве значения аргумента `Вася лох`, либо значения аргумента будет передано вместе со скобками - `"Вася лох"`, которые нужно удалять `$params[$key] = trim(array_shift($argv), '\'"');`. Как вариант можно адаптировать http://php.net/manual/function.getopt.php#83414 (код не проверял).

Использовать `echo`  не вариант - о том как правильно выводить\вводить данные в консоли http://php.net/commandline.io-streams 
