### PR TITLE
Update waDbStatement.class.php

### DIFF
--- a/wa-system/database/waDbStatement.class.php
+++ b/wa-system/database/waDbStatement.class.php
@@ -81,7 +81,7 @@ final class waDbStatement
 
         $matches = array();
 
-        if (preg_match_all('/([sibfl]?)(\?|:[A-z0-9_]+)/', $this->query, $matches, PREG_OFFSET_CAPTURE)) {
+        if (preg_match_all('/([sibfl]?)(\?|:[a-zA-Z0-9_]+)/', $this->query, $matches, PREG_OFFSET_CAPTURE)) {
             $unnamed_count = 0;
             foreach ($matches[0] as $id => $match) {
                 $match[2] = $matches[1][$id][0];


### PR DESCRIPTION
Возникли проблемы при использовании регулярок в MySQL запросах. Например "[[:<:]]text". Старая регулярка думает что ":]]text" это плейсхолдер.
