### PR TITLE
Call a parent run() method from waJsonController

### DIFF
--- a/wa-system/controller/waJsonController.class.php
+++ b/wa-system/controller/waJsonController.class.php
@@ -25,7 +25,7 @@ abstract class waJsonController extends waController
     
     public function run($params = null)
     {
-        $this->execute();
+        parent::run($params);
         $this->display();
     }
 


### PR DESCRIPTION
Иначе не отрабатывает `preExecute()`