### PR TITLE
Set default content-type for response as application/json

### DIFF
--- a/wa-system/controller/waJsonController.class.php
+++ b/wa-system/controller/waJsonController.class.php
@@ -49,4 +49,10 @@ abstract class waJsonController extends waController
     {
         $this->errors[] = array($message, $data);
     }
+
+    protected function preExecute()
+    {
+        $this->getResponse()->addHeader('Content-type', 'application/json');
+        parent::preExecute();
+    }
 }


### PR DESCRIPTION
Было бы логично, если бы по умолчанию `waJsonController` отдавал view с `Content-type=application/json`. Без #57 работать не будет