### PR TITLE
Generate notices when using deprecated functions, methods and classes

### DIFF
--- a/wa-apps/blog/lib/actions/cron/blogCronSchedule.cli.php
+++ b/wa-apps/blog/lib/actions/cron/blogCronSchedule.cli.php
@@ -7,6 +7,10 @@
 
 class blogCronScheduleCli extends waCliController
 {
+    public function __construct()
+    {
+        waLog::deprecated(__CLASS__);
+    }
 
     public function execute()
     {

--- a/wa-apps/blog/lib/classes/blogViewHelper.class.php
+++ b/wa-apps/blog/lib/classes/blogViewHelper.class.php
@@ -15,6 +15,7 @@ class blogViewHelper extends waAppViewHelper
      */
     public function rss()
     {
+        waLog::deprecated(__METHOD__);
         return $this->rssUrl();
     }
 

--- a/wa-apps/blog/plugins/emailsubscription/lib/blogEmailsubscriptionPlugin.class.php
+++ b/wa-apps/blog/plugins/emailsubscription/lib/blogEmailsubscriptionPlugin.class.php
@@ -53,6 +53,9 @@ class blogEmailsubscriptionPlugin extends blogPlugin
      */
     public function cronAction($params)
     {
+
+        waLog::deprecated(__METHOD__);
+
         $model = new blogEmailsubscriptionLogModel();
         $row = $model->getByField('status', 0);
         if ($row) {

--- a/wa-apps/contacts/lib/models/contactsRights.model.php
+++ b/wa-apps/contacts/lib/models/contactsRights.model.php
@@ -48,7 +48,8 @@ class contactsRightsModel extends waModel
      * @return array|boolean category_id => read|write or TRUE for admins 
      */
     public function getAllowedCategories($user_id = null) {
-        
+
+        waLog::deprecated(__METHOD__);
         return true;
         
     }

--- a/wa-apps/photos/lib/models/photosAlbum.model.php
+++ b/wa-apps/photos/lib/models/photosAlbum.model.php
@@ -56,6 +56,9 @@ class photosAlbumModel extends waModel
      */
     public function getStaticAlbums($public_only = false, $owned_only = false)
     {
+
+        waLog::deprecated(__METHOD__);
+
         $user = wa()->getUser();
         $sql = "SELECT a.id, a.name FROM ".$this->table." a ";
         if ($public_only) {

--- a/wa-system/contact/waContactFields.class.php
+++ b/wa-system/contact/waContactFields.class.php
@@ -247,6 +247,7 @@ class waContactFields
      */
     public static function createField($field)
     {
+        waLog::deprecated(__METHOD__);
         if (!($field instanceof waContactField)) {
             throw new waException('Invalid contact field '.print_r($field, TRUE));
         }

--- a/wa-system/controller/waController.class.php
+++ b/wa-system/controller/waController.class.php
@@ -75,6 +75,7 @@ abstract class waController
      */
     public function log($action, $count = null, $contact_id = null, $params = null)
     {
+        waLog::deprecated(__METHOD__);
         return $this->logAction($action, $params, null, $contact_id);
     }
 

--- a/wa-system/database/waModel.class.php
+++ b/wa-system/database/waModel.class.php
@@ -574,6 +574,7 @@ class waModel
      */
     public function multiInsert($data)
     {
+        waLog::deprecated(__METHOD__);
         return $this->multipleInsert($data);
     }
 

--- a/wa-system/helper/misc.php
+++ b/wa-system/helper/misc.php
@@ -52,6 +52,7 @@ function wa_dumpc()
  */
 function wa_print_r()
 {
+    waLog::deprecated(__FUNCTION__);
     $args = func_get_args(); // Can't be used as a function argument directly before PHP 5.3
     call_user_func_array('wa_dumpc', $args);
     exit;
@@ -131,6 +132,7 @@ function wa_is_int($val)
  */
 function int_ok($val)
 {
+    waLog::deprecated(__FUNCTION__);
     return wa_is_int($val);
 }
 

--- a/wa-system/locale/waLocale.class.php
+++ b/wa-system/locale/waLocale.class.php
@@ -72,6 +72,8 @@ class waLocale
      */
     public static function translate($domain, $locale, $msgid)
     {
+        waLog::deprecated(__METHOD__);
+
         $old_locale = null;
         // load new locale
         if (self::$locale != $locale) {

--- a/wa-system/log/waLog.class.php
+++ b/wa-system/log/waLog.class.php
@@ -31,6 +31,15 @@ class waLog
         fclose($fd);
         return true;
     }
+    
+    public static function deprecated($message) {
+        
+        if(version_compare(PHP_VERSION, "5.3.0", ">=")) {
+            trigger_error( $message, E_USER_DEPRECATED);
+        } else {
+            trigger_error( "Deprecated " . $message, E_USER_NOTICE);
+        }
+    }
 }
 
 // EOF

--- a/wa-system/payment/waPayment.class.php
+++ b/wa-system/payment/waPayment.class.php
@@ -400,6 +400,7 @@ abstract class waPayment extends waSystemPlugin
      */
     public function getSettingsList()
     {
+        waLog::deprecated(__METHOD__);
         throw new waException('Use getSettingsHTML instead');
     }
 
@@ -415,6 +416,7 @@ abstract class waPayment extends waSystemPlugin
      */
     final public static function listModules($options = array())
     {
+        waLog::deprecated(__METHOD__);
         throw new waException('Use enumerate instead');
     }
 
@@ -625,6 +627,7 @@ abstract class waPayment extends waSystemPlugin
      */
     final public static function addTransactionData($wa_transaction_id, $result = null)
     {
+        waLog::deprecated(__METHOD__);
         return true;
     }
 
@@ -674,6 +677,7 @@ abstract class waPayment extends waSystemPlugin
      */
     public static function execTransactionCallback($request, $module_id)
     {
+        waLog::deprecated(__METHOD__);
         return self::callback($module_id, $request);
     }
 

--- a/wa-system/workflow/waWorkflow.class.php
+++ b/wa-system/workflow/waWorkflow.class.php
@@ -199,6 +199,7 @@ class waWorkflow
      */
     public function getActionByClass($class_name)
     {
+        waLog::deprecated(__METHOD__);
         $actions = $this->getAvailableActions();
         $action_id = array_search($class_name, $actions); // !!! fails when item is an array
 
@@ -214,6 +215,7 @@ class waWorkflow
      */
     public function getStateByClass($class_name)
     {
+        waLog::deprecated(__METHOD__);
         $states = $this->getAvailableStates();
         $state_id = array_search($class_name, $states); // !!! fails when item is an array
 
@@ -240,6 +242,7 @@ class waWorkflow
      */
     public function getState($params = null)
     {
+        waLog::deprecated(__METHOD__);
         if ($params) {
             return $this->getStateById($params['state_id']);
         }
@@ -255,6 +258,7 @@ class waWorkflow
      */
     public function getActions()
     {
+        waLog::deprecated(__METHOD__);
         $args = func_get_args();
         $params = isset($args[0]) ? $args[0] : null;
         $name_only = isset($args[1]) ? $args[1] : false;

--- a/wa-system/workflow/waWorkflowState.class.php
+++ b/wa-system/workflow/waWorkflowState.class.php
@@ -86,6 +86,7 @@ class waWorkflowState extends waWorkflowEntity
      */
     protected function getAvailableActions($params = null)
     {
+        waLog::deprecated(__METHOD__);
         /**
          * return array(
          *        'Workflow1Action1',


### PR DESCRIPTION
Сообщения об использовании устаревших частей фреймворка помогут при проверке работоспособности и совместимости приложений и плагинов с новыми версиями фреймворка.