### PR TITLE
Передаем в шаблон comment.html URL аватары пользователя размера 50x50

### DIFF
--- a/wa-apps/blog/lib/actions/frontend/blogFrontendComment.controller.php
+++ b/wa-apps/blog/lib/actions/frontend/blogFrontendComment.controller.php
@@ -166,7 +166,7 @@ class blogFrontendCommentController extends waJsonController
         $this->getResponse()->addHeader('Content-type', 'application/json');
         if ($this->comment_id && ($comment = $this->comment_model->getById($this->comment_id) )) {
             $count = $this->comment_model->getCount($comment['blog_id'], $comment['post_id']);
-            $comments = $this->comment_model->prepareView(array($comment), array('photo_url_20'),array('user'=>true,'escape'=>true));
+            $comments = $this->comment_model->prepareView(array($comment), array('photo_url_20', 'photo_url_50'),array('user'=>true,'escape'=>true));
 
             $theme = waRequest::param('theme', 'default');
             $theme_path = wa()->getDataPath('themes', true).'/'.$theme;


### PR DESCRIPTION
Когда шаблон `comment.html` вызывается из `comments.html` (в теме Default, например), то для автора комментария URL фото передается для двух вариантов: 20×20 и 50×50. А когда добавляешь новый комментарий с помощью json-запроса, в `comment.html` передается только 20×20.
