### PR TITLE
Исправление метода getGroupboxControl 

### DIFF
--- a/wa-system/util/waHtmlControl.class.php
+++ b/wa-system/util/waHtmlControl.class.php
@@ -573,13 +573,13 @@ HTML;
             unset($checkbox_params['options']);
         }
         $id = 0;
-        foreach ($options as $option) {
+        foreach ($options as $key => $option) {
             //TODO check that $option is array
             $checkbox_params['value'] = empty($option['value']) ? $option['value'] : 1;
             $checkbox_params['checked'] = in_array($option['value'], $params['value'], true) || !empty($params['value'][$option['value']]);
             $checkbox_params['title'] = empty($option['title']) ? null : $option['title'];
             $checkbox_params['description'] = ifempty($option['description']);
-            $control .= self::getControl(self::CHECKBOX, $option['value'], $checkbox_params);
+            $control .= self::getControl(self::CHECKBOX, $key, $checkbox_params);
             if (++$id < count($options)) {
                 $control .= $params['control_separator'];
             }


### PR DESCRIPTION
Исправление к следующему:

Запрос №1299018

В waHtmlControl.class.php ошибка, не позволяющая правильно использовать GROUPBOX

Не правильно использована функция getControl($type, $name, $params = array())
Вместо $name на нее подается $option['value'], а $option['value'] для гроупбокса всегда либо 0 либо 1
Таким образом режутся индексы имен чекбоксов, и это меняет результаты отображения в дальнейшем.

Должно быть так: $control .= self::getControl(self::CHECKBOX, $key, $checkbox_params);
где $key - индекс массива $options

Ошибка в этом методе не позволяет правильно конструировать форму с гроупбоксами. Это обнаружилось при разработке плагина customorderfields
