### PR TITLE
Автоматическая фокусировка на редакторе editor.js

### DIFF
--- a/wa-content/js/jquery-wa/editor.js
+++ b/wa-content/js/jquery-wa/editor.js
@@ -37,6 +37,7 @@ jQuery.fn.waEditor = function (options) {
         options = $.extend({
             //boldTag: 'b',
             //italicTag: 'i',
+            editorOnLoadFocus: true,
             deniedTags: false,
             minHeight: 300,
             buttonSource: false,
@@ -116,7 +117,12 @@ jQuery.fn.waEditor = function (options) {
         editor.setOption("minLines", 2);
         editor.setOption("maxLines", 10000);
         editor.setAutoScrollEditorIntoView(true);
-
+        
+        if (options['editorOnLoadFocus'])
+        {
+          editor.focus();
+          editor.navigateTo(0, 0);
+        }
 
         editor.commands.addCommands([{
             name: 'waSave',
@@ -212,8 +218,24 @@ jQuery.fn.waEditor = function (options) {
             wrapper.find('.html').parent().addClass('selected');
             wrapper.find('.redactor_box').hide();
             wrapper.find('.ace').show();
+            if (options['editorOnLoadFocus'])
+            {
+                editor.focus();
+                editor.navigateTo(0, 0);
+            }
         } else {
             wrapper.find('.ace').hide();
+            if (options['editorOnLoadFocus'])
+            {
+                if (!options['iframe']) {
+                    self.redactor('focus');
+                }
+                else {
+                    setTimeout(function(){
+                        self.redactor('focus');
+                    }, 100);
+                }
+            }
         }
     });
     return result;


### PR DESCRIPTION
Убирает прыгание страницы при инициализации редактора. Фокус на редактор лучше выставлять по надобности, а не принудительно при каждой инициализации.
