### PR TITLE
DO NOT MERGE. Discuss first! :)

### DIFF
--- a/wa-system/autoload/waAutoload.class.php
+++ b/wa-system/autoload/waAutoload.class.php
@@ -216,6 +216,7 @@ class waAutoload
 
         'waFiles'                  => 'file/waFiles.class.php',
         'waTheme'                  => 'file/waTheme.class.php',
+        'waRecursivePhpFilterIterator' => 'file/waRecursivePhpFilterIterator.class.php',
 
         'waLayout'                 => 'layout/waLayout.class.php',
 

--- a/wa-system/file/waRecursivePhpFilterIterator.class.php
+++ b/wa-system/file/waRecursivePhpFilterIterator.class.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of Webasyst framework.
+ *
+ * Licensed under the terms of the GNU Lesser General Public License (LGPL).
+ * http://www.webasyst.com/framework/license/
+ *
+ * @link http://www.webasyst.com/
+ * @author Serge Rodovnichenko <sergerod@gmail.com>
+ * @copyright 2014 Serge Rodovnichenko
+ * @package wa-system
+ * @subpackage file
+ */
+class waRecursivePhpFilterIterator extends RecursiveFilterIterator
+{
+
+    protected $ignore=array();
+
+    public function accept()
+    {
+        $filename = $this->current()->getFilename();
+
+        if($filename[0] === '.') {
+            return FALSE;
+        }
+
+        if(isset($this->ignore[$filename])) {
+            return FALSE;
+        }
+
+        return $this->isDir() || substr($filename, -4) === '.php';
+    }
+
+    public function ignore($items)
+    {
+        if(is_array($items) && !empty($items)) {
+            $this->ignore = array_flip($items);
+        }
+    }
+}


### PR DESCRIPTION
Простите, но нет нестабильной девелоперской ветки, только `master` поэтому реквест сюда отправляю.

Увидел на форуме вопросы про нагрузку, решил под профайлером позапускать фреймворк с приложениями. Нашел метод, потребляющий ресурсов — `waAppConfig::getPHPFiles()`.

Переписал его с использованием SPL итераторов. Погонял под профайлером, переключая ветки в git и очищая кэш. Конкретные цифры разнятся, но разница в 20%-25% остается.

Вот тут в двух соседних окнах открыл один из результатов запуска. Слева теперешний `waAppConfig::getPHPFiles()`, справа — переписан с использованием SPL (надо учитывать две строки с `getPHPFiles` и с `RecursivePhpFilterIterator` чтоб все по-честному было.

О минусах ниже

![_162](https://cloud.githubusercontent.com/assets/40233/5348028/a501cdc0-7f3d-11e4-9165-f7468ad94270.png)

Минус в потере обратной совместимости. Теперешний метод вызывает метод `isIgnoreFile($file)` чтобы определить надо ли игнорировать файл/директорию. И наследники этот метод могут переопределить — из доступных мне приложений это делает **mailer**, добавляя к списку игнорируемых имя 'swift'.

В новой редакции я предусмотрел возможность передачи массива дополнительных имен для игнорирования (все начинающиеся на точки и так будут пропущены) без использования `isIgnoreFile()`, но **mailer** -то поправить не могу.

Может кто-то тоже погонять/потестировать и посравнивать? Может удастся разработчиков убедить, что еще не поздно, тем более, что метод недокументирован. :) Выпускают-же обновления, требующие непременно новой версии фреймворка :)