### PR TITLE
Баг с иконками у плагинов

### DIFF
--- a/wa-content/css/wa/wa-1.3.css
+++ b/wa-content/css/wa/wa-1.3.css
@@ -1061,6 +1061,9 @@ i.icon10 { background-repeat:no-repeat; background-image: url(../../../wa-conten
 (min-resolution: 192dpi) {
     i.icon10 { background-image: url(../../../wa-content/img/icon10@2x.png); background-size: 120px 50px; }
     i.icon16 { background-image: url(../../../wa-content/img/icon16@2x.png); background-size: 512px 128px; }
+    #plugin-list .icon16:not(.star) {
+        background-size: cover;
+    }
 }
 
 


### PR DESCRIPTION
Исправлен глюк с иконками у плагинов, описанный в [issue #89](https://github.com/webasyst/shop-script/issues/89)
Возможно вставить иконку плагина под ретина в 2 раза большую по размерам и она автоматом адаптируется.