### PR TITLE
Исправление бага с csrf

### DIFF
--- a/wa-system/user/waAuthUser.class.php
+++ b/wa-system/user/waAuthUser.class.php
@@ -53,7 +53,7 @@ class waAuthUser extends waUser
             }
             // check CSRF cookie
             if (!waRequest::cookie('_csrf')) {
-                waSystem::getInstance()->getResponse()->setCookie('_csrf', uniqid('', true));
+                waSystem::getInstance()->getResponse()->setCookie('_csrf', addslashes(uniqid('', true)));
             }
         }
     }


### PR DESCRIPTION
Иногда в cookie _csrf попадала кавычка, что в дальнейшем ломало некоторые шаблоны и блокировало обновление профиля.
Сделал экранирование.