### PR TITLE
Забыто слово "new" при создании объекта blogPagesActions

### DIFF
--- a/wa-apps/blog/lib/actions/backend/blogBackendUpload.controller.php
+++ b/wa-apps/blog/lib/actions/backend/blogBackendUpload.controller.php
@@ -17,7 +17,7 @@ class blogBackendUploadController extends waController
     {
         // When Photos app is not used to store images,
         // use the default system uploader to do all the work
-        $actions = blogPagesActions();
+        $actions = new blogPagesActions();
         $actions->run('uploadimage');
     }
 


### PR DESCRIPTION
В `blogBackendUploadController::uploadToFilder`
есть строка

        $actions = blogPagesActions();

на которую php ругается "PHP Fatal error: Call to undefined function blogPagesActions() in ..."

Такой функции действительно нигде нет (https://github.com/webasyst/webasyst-framework/search?utf8=%E2%9C%93&q=blogPagesActions), есть такой класс.