### PR TITLE
HTTPS detection improved

### DIFF
--- a/wa-system/request/waRequest.class.php
+++ b/wa-system/request/waRequest.class.php
@@ -474,6 +474,9 @@ class waRequest
         if (!empty($_SERVER['HTTP_SSL']) && $_SERVER['HTTP_SSL'] == 1) {
             return true;
         }
+        if (!empty($_SERVER['HTTP_X_SSL']) && (strtolower($_SERVER['HTTP_X_SSL']) == 'yes' || $_SERVER['HTTP_X_SSL'] == '1')) {
+            return true;
+        }
         if(!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
             return true;
         }


### PR DESCRIPTION
На довольно популярном хостинге ht-systems.ru нашелся еще один вариант указания работы по SSL-протоколу `'HTTP_X_SSL'=>'yes'` :scream: 