### PR TITLE
Do not merge if no ID's to merge.

### DIFF
--- a/wa-apps/blog/lib/handlers/contacts.merge.handler.php
+++ b/wa-apps/blog/lib/handlers/contacts.merge.handler.php
@@ -7,6 +7,10 @@ class blogContactsMergeHandler extends waEventHandler
         $master_id = $params['id'];
         $merge_ids = $params['contacts'];
 
+        if(!$merge_ids) {
+            return null;
+        }
+
         $m = new waModel();
 
         foreach(array(


### PR DESCRIPTION
Этот handler внезапно вызывается, когда в Магазине включено подтверждение регистрации по e-mail. Пользователь переходит по ссылке из письма, видит, что регистрация подтвердилась и работает. Однако у e-mail в wa_contact_emails статус остается 'unconfirmed' потому, что в процессе обработки подтверждения вызывается этот handler, пытается выполнить SQL запрос типа `UPDATE blog_comments SET contact_id='NNN' WHERE contact_id IN()`. MySQL дает ошибку при пустом `IN()` и процесс подтверждения прекращается.