### PR TITLE
Allow to add protocol-less absolute URLs for JS and CSS

### DIFF
--- a/wa-system/response/waResponse.class.php
+++ b/wa-system/response/waResponse.class.php
@@ -336,7 +336,7 @@ class waResponse
                 $url .= '.'.time();
             }
         // Support external links
-        } elseif (strpos($url, '://') === false) {
+        } elseif ((strpos($url, '://') === false) && (strpos($url, '//') !== 0)) {
             $url = wa()->getRootUrl().$url;
         }
 
@@ -447,7 +447,7 @@ $(function () {
                 $url .= '.'.time();
             }
         // Support external links
-        } elseif (strpos($url, '://') === false) {
+        } elseif ((strpos($url, '://') === false) && (strpos($url, '//') !== 0)) {
             $url = wa()->getRootUrl().$url;
         }
 


### PR DESCRIPTION
Добавлена возможность вставлять абсолютные ссылки на скрипты и файлы стилей без указания протокола. Например `//cdn.yandex.ru/jquery/jquery.min.js` или вроде того.