### PR TITLE
Fix waSystem::getFactory

### DIFF
--- a/wa-system/waSystem.class.php
+++ b/wa-system/waSystem.class.php
@@ -181,25 +181,29 @@ class waSystem
      * @param string $class
      * @param array $options
      * @param mixed $first_param
-     * @return mixed
+     * @return object
      */
-    protected function getFactory($name, $class, $options = array(), $first_param = false)
+    protected function getFactory($name, $class, array $options = array(), $first_param = false)
     {
-        if ($config = $this->getConfig()->getFactory($name)) {
-            if (is_array($config)) {
-                $class = $config[0];
-                $options = isset($config[1]) ? $config[1] : $options;
-            } else {
-                $class = $config;
-            }
-        }
         if (!isset($this->factories[$name])) {
+            if ($config = $this->getConfig()->getFactory($name)) {
+                if (is_array($config)) {
+                    $class = $config[0];
+                    if (isset($config[1])) {
+                        $options = array_merge((array)$config[1], $options);
+                    }
+                } else {
+                    $class = $config;
+                }
+            }
+            
             if ($first_param !== false) {
                 $this->factories[$name] = new $class($first_param, $options);
             } else {
                 $this->factories[$name] = new $class($options);
             }
         }
+        
         return $this->factories[$name];
     }
 


### PR DESCRIPTION
1. Поправил описание.
2. Добавил контроль типа для параметра $options.
3. Исправил логику работы: не имеет смысла загружать $config если объект уже создан, $options объединяется с базовым $config (в старом варианте они игнорировались при наличии $config).