### PR TITLE
Fix XML format representation

### DIFF
--- a/wa-system/file/waNet.class.php
+++ b/wa-system/file/waNet.class.php
@@ -215,7 +215,7 @@ class waNet
                             /**
                              * @var SimpleXMLElement $content
                              */
-                            $content = (string)$content->__toString();
+                            $content = (string)$content->asXML();
                         } elseif ($class == 'DOMDocument') {
                             /**
                              * @var DOMDocument $content


### PR DESCRIPTION
Use `asXML()` method to get a well-formed XML. `__toString()` returns only the text content of the node (an empty string for root in most cases)