### PR TITLE
Install/Uninstall/Update and DB for System Plugins

### DIFF
--- a/wa-system/plugin/waSystemPlugin.class.php
+++ b/wa-system/plugin/waSystemPlugin.class.php
@@ -400,10 +400,31 @@ abstract class waSystemPlugin
     }
 
     /**
-     * @todo write smth
+     *
      */
     protected function install()
     {
+        $file_db = $this->path.'/lib/config/db.php';
+        if (file_exists($file_db)) {
+            $schema = include($file_db);
+            $model = new waModel();
+            $model->createSchema($schema);
+        }
+        // check install.php
+        $file = $this->path.'/lib/config/install.php';
+        if (file_exists($file)) {
+            include($file);
+            // clear db scheme cache, see waModel::getMetadata
+            try {
+                // remove files
+                $path = waConfig::get('wa_path_cache').'/db/';
+                waFiles::delete($path, true);
+            } catch (waException $e) {
+                waLog::log($e->__toString());
+            }
+            // clear runtime cache
+            waRuntimeCache::clearAll();
+        }
     }
 
     /**

--- a/wa-system/plugin/waSystemPlugin.class.php
+++ b/wa-system/plugin/waSystemPlugin.class.php
@@ -543,6 +543,7 @@ abstract class waSystemPlugin
     public function uninstall($force = false)
     {
         $full_id = "{$this->type}_{$this->id}";
+        $info = array('type' => $this->type, 'id' => $this->id);
 
         // check uninstall.php
         $uninstall_script = $this->path.'/lib/config/uninstall.php';
@@ -573,6 +574,11 @@ abstract class waSystemPlugin
 
         // Remove cache of the application
         waFiles::delete(wa()->getAppCachePath('', 'webasyst'));
+
+        /**
+         * @event uninstall_system_plugin
+         */
+        wa()->event(array('webasyst', 'uninstall_system_plugin'), $info);
     }
 
     /**

--- a/wa-system/plugin/waSystemPlugin.class.php
+++ b/wa-system/plugin/waSystemPlugin.class.php
@@ -305,10 +305,104 @@ abstract class waSystemPlugin
         } else {
             throw new waException(sprintf("%s plugin class %s not found ", $type, $class));
         }
+
+        $plugin->checkUpdates();
+
         return $plugin;
     }
 
+    /**
+     * Checks for installation or update scripts and runs them
+     *
+     * @throws Exception
+     */
+    protected function checkUpdates()
+    {
+        $app_settings_model = new waAppSettingsModel();
+        $full_id = "{$this->type}_{$this->id}";
+        $time = $app_settings_model->get(array('webasyst', $full_id), 'update_time');
+        if (!$time) {
+            try {
+                $this->install();
+            } catch (Exception $e) {
+                waLog::log($e->getMessage());
+                throw $e;
+            }
+            $ignore_all = true;
+        } else {
+            $ignore_all = false;
+        }
+
+        $is_debug = waSystemConfig::isDebug();
+
+        if (!$is_debug) {
+            $cache = new waVarExportCache('updates', 0, "webasyst.".$full_id);
+            if ($cache->isCached() && $cache->get() <= $time) {
+                return;
+            }
+        }
+        $path = $this->path.'/lib/updates';
+        $cache_database_dir = wa()->getConfig()->getPath('cache').'/db';
+        if (file_exists($path)) {
+            $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path), RecursiveIteratorIterator::SELF_FIRST);
+            $files = array();
+            foreach ($iterator as $file) {
+                /**
+                 * @var SplFileInfo $file
+                 */
+                if ($file->isFile() && preg_match('/^[0-9]+\.php$/', $file->getFilename())) {
+                    $t = substr($file->getFilename(), 0, -4);
+                    if ($t > $time) {
+                        $files[$t] = $file->getPathname();
+                    }
+                }
+            }
+            ksort($files);
+            if (!$is_debug && !empty($cache)) {
+                // get last time
+                if ($files) {
+                    $keys = array_keys($files);
+                    $cache->set(end($keys));
+                } else {
+                    $cache->set($time ? $time : 1);
+                }
+            }
+            foreach ($files as $t => $file) {
+                try {
+                    if (!$ignore_all) {
+                        $this->includeUpdate($file);
+                        waFiles::delete($cache_database_dir);
+                        $app_settings_model->set(array('webasyst', $full_id), 'update_time', $t);
+                    }
+                } catch (Exception $e) {
+                    if ($is_debug) {
+                        echo $e;
+                    }
+                    // log errors
+                    waLog::log($e->__toString());
+                    break;
+                }
+            }
+        } else {
+            $t = 1;
+        }
+
+        if ($ignore_all) {
+            if (!isset($t) || !$t) {
+                $t = 1;
+            }
+            $app_settings_model->set(array('webasyst', $full_id), 'update_time', $t);
+        }
+    }
+
     protected function initControls()
+    {
+    }
+
+    /**
+     * @todo write smth
+     */
+    protected function install()
     {
     }
 
@@ -441,7 +535,15 @@ abstract class waSystemPlugin
         return $settings;
     }
 
-
+    /**
+     * Includes file with update
+     *
+     * @param string $file
+     */
+    private function includeUpdate($file)
+    {
+        include($file);
+    }
 
     /**
      *


### PR DESCRIPTION
Возвращаясь к теме webasyst/webasyst-framework#68

Черновой вариант методов `checkUpdates()`, `install()` и `uninstall()` для системных плагинов. Поддерживается создание и удаление таблиц, проверка и исполнение файлов обновлений, скриптов `install.php` и `uninstall.php`

Также в метод `uninstall()` добавлено событие **`webasyst.uninstall_system_plugin`** которое будет полезно приложениям, создающим методы доставки или оплаты, или оповещения по SMS — приложения смогут удалять методы, ссылающиеся на удаленный плагин или как-то по-другому реагировать.

Таймстампы проверки обновлений плагинов хранятся в `wa_app_settings` в виде `webasyst.{plugin->type}_{plugin_id}`. Чтобы избежать ситуации, когда есть 2 плагина разных типов с одинаковым названием. Никаких других идей на этот счет мне в голову не пришло, может @VladislavWA что-нибудь более изящное подскажет :laughing: 
