### PR TITLE
Тип отображения окна при авторизации через Facebook

### DIFF
--- a/wa-system/auth/adapters/facebookAuth.class.php
+++ b/wa-system/auth/adapters/facebookAuth.class.php
@@ -19,7 +19,7 @@ class facebookAuth extends waOAuth2Adapter
     {
         // Login dialog url
         $redirect_uri = $this->getOption('redirect_uri');
-        return self::LOGIN_URL."?client_id=".$this->app_id."&scope=email&redirect_uri=".urlencode($redirect_uri);
+        return self::LOGIN_URL."?client_id=".$this->app_id."&scope=email&display=popup&redirect_uri=".urlencode($redirect_uri);
     }
 
     public function getAccessToken($code)


### PR DESCRIPTION
Без параметра &display=popup ругается на тип отображения и просит сделать окно больше
http://joxi.ru/E2pWd0KSB3O6Em?d=1