### PR TITLE
Added getter for $domain_field in waPageModel

### DIFF
--- a/wa-system/page/models/waPage.model.php
+++ b/wa-system/page/models/waPage.model.php
@@ -245,4 +245,9 @@ class waPageModel extends waModel
             $cache->deleteGroup('pages');
         }
     }
+    
+    public function getDomainField()
+    {
+        return $this->domain_field;
+    }
 }


### PR DESCRIPTION
I need it in my product, and I have found no better option to get that value than to loop through the table schema and strpos/preg_match 'domain' string on field names. It's an ugly hack which will not necessarily work reliably with all apps using this model, because the $domain_field value can not contain 'domain' string; e.g., 'site_id', etc.