### PR TITLE
Seamless password hash salt integration

### DIFF
--- a/wa-config/SystemConfig.class.php.example
+++ b/wa-config/SystemConfig.class.php.example
@@ -3,6 +3,27 @@
 require_once realpath(dirname(__FILE__).'/../').'/wa-system/autoload/waAutoload.class.php';
 waAutoload::register();
 
+# wa_password_hash* examples suitable for seamless salt integration
+#
+#function wa_password_hash($password)
+#{
+#    return password_hash($password, PASSWORD_BCRYPT);
+#}
+#
+#function wa_password_hash_verify($password, $hash)
+#{
+#    if (substr($hash, 0, 1) === "$") {
+#        return password_verify($password, $hash);
+#    } else {
+#        return md5($password) === $hash;
+#    }
+#}
+#
+#function wa_password_hash_shouldupgrade($hash)
+#{
+#    return substr($hash, 0, 1) !== "$" && iconv_strlen($hash) == 32;
+#}
+
 class SystemConfig extends waSystemConfig
 {
 		

--- a/wa-system/auth/waAuth.class.php
+++ b/wa-system/auth/waAuth.class.php
@@ -173,7 +173,12 @@ class waAuth implements waiAuth
         if ($login && strlen($login)) {
             $user_info = $this->getByLogin($login);
             if ($user_info && ($user_info['is_user'] > 0 || !$this->options['is_user']) &&
-                waContact::getPasswordHash($password) === $user_info['password']) {
+                waContact::verifyPasswordHash($password, $user_info['password'])) {
+                if (isset($user_info['id']) && waContact::shouldUpgradePasswordHash($user_info['password'])) {
+                    $contact_model = new waContactModel();
+                    $user_info['password'] = waContact::getPasswordHash($password);
+                    $contact_model->updateById($user_info['id'], array('password' => $user_info['password']));
+                }
                 $auth_config = wa()->getAuthConfig();
                 if (wa()->getEnv() == 'frontend' && !empty($auth_config['params']['confirm_email'])) {
                     $contact_emails_model = new waContactEmailsModel();

--- a/wa-system/contact/waContact.class.php
+++ b/wa-system/contact/waContact.class.php
@@ -1139,6 +1139,48 @@ class waContact implements ArrayAccess
     }
 
     /**
+     * Verifies that a password matches a hash.
+     *
+     * If configuration file wa-config/SystemConfig.class.php contains information about user-defined function
+     * wa_password_hash_verify(), then that function is used for hash checking. Otherwise, this function uses
+     * getPasswordHash() method for generating and checking hash.
+     * See description of PHP function password_verify().
+     *
+     * @param string $password Password string
+     * @param string $hash Password hash
+     * @return boolean
+     */
+    public static function verifyPasswordHash($password, $hash)
+    {
+        if (function_exists('wa_password_hash_verify')) {
+            return wa_password_hash_verify($password, $hash);
+        } else {
+            return self::getPasswordHash($password) === $hash;
+        }
+    }
+
+    /**
+     * Checks that a password hash should upgrade (e.g., change algo and/or add a salt).
+     *
+     * By default, hash is generated using PHP function md5(). If configuration file wa-config/SystemConfig.class.php
+     * contains user-defined function wa_password_hash_shouldupgrade(), then that function is used for determining of
+     * upgrade desirability. This function returns false otherwise, i.e. upgrade is not required.
+     * wa_password_hash_shouldupgrade() is useful for seamless password salt integration. It should look at prefix of
+     * hash string to detect upgrade desirability.
+     *
+     * @param string $hash Password hash
+     * @return boolean
+     */
+    public static function shouldUpgradePasswordHash($hash)
+    {
+        if (function_exists('wa_password_hash_shouldupgrade')) {
+            return wa_password_hash_shouldupgrade($hash);
+        } else {
+            return false;
+        }
+    }
+
+    /**
      * Adds contact to a category.
      *
      * @param int|string $category_id Category's simple numeric or system string key (app_id)


### PR DESCRIPTION
Бесшовное внедрение соли. Соль автоматически добавляется в базу при очередном логине пользователя. Требуется добавление функций wa_password_hash, wa_password_hash_verify и wa_password_hash_shouldupgrade в wa-config/SystemConfig.class.php (см. пример в wa-config/SystemConfig.class.php.example). Если функции не добавлены, то код продолжает корректно работать с дефолтным md5. Также корректно работает с уже имеющейся функцией wa_password_hash, если она была создана ранее.