### PR TITLE
На обсуждение. Произвольные события в темах дизайна

### DIFF
--- a/wa-system/view/waViewHelper.class.php
+++ b/wa-system/view/waViewHelper.class.php
@@ -1108,4 +1108,35 @@ HTML;
         }
         return self::$helpers[$app];
     }
+    
+    
+    
+    /**
+     * @param string $app_id Application id.
+     * @param string $name Event name.
+     * @param null $params Parameters passed to event handlers.
+     * @param string $return_type
+     * @return null|string|array
+     */
+    public function event($app_id, $name, &$params = null, $return_type = 'string')
+    {
+        $result = null;
+
+        if(wa()->appExists($app_id)) {
+            $plugins = wa($app_id)->event('custom.'.$name, $params);
+
+            if(is_array($plugins)) {
+                if ($return_type == 'string') {
+                    $result = '';
+                    foreach ($plugins as $plugin) {
+                        $result .= $plugin;
+                    }
+                } elseif ($return_type == 'array') {
+                    $result = $plugins;
+                }
+            }
+        }
+
+        return $result;
+    }
 }


### PR DESCRIPTION
Возвращаясь к теме, которую подняли в #146, хочу предложить решение, основанное на событиях.
Позволяет во многих случаях отказаться от статических хелперов в плагинах.

Вместо этого вызываем событие, на которое плагин заранее подписан, прямо из шаблона темы.

Если плагин подписан на событие, которое никогда не вызывается, ошибок не будет (как и с хелперами, впрочем).
Но! и если плагин (или приложение целиком) удалили, а вызов события остался, ничего страшного не произойдёт.

Для некоторых плагинов, которые могут работать в других приложениях, если добавить что-то в < head />, можно будет по договорённости использовать событие с одинаковым названием.

С точки зрения безопасности возможно вызвать только тот код, для которого разработчик предусмотрел такую возможность.

Если идея достойна, хотелось бы услышать комментарии по реализации.

Во-первых, я не придумал ни одного примера, где результат вызова нужен будет в виде массива, но возможность такую всё-равно оставил. Может отдельным методом правильнее? Или вообще убрать?

Во-вторых, если кто-то напишет приложение _event_, с ним будут проблемы :)

Ну и префикс _custom._ нужен для того, чтобы никто не вызывал системные события самостоятельно.
