### PR TITLE
compress: allow call_user_func[_array] functions

### DIFF
--- a/wa-system/webasyst/lib/cli/webasystCompress.cli.php
+++ b/wa-system/webasyst/lib/cli/webasystCompress.cli.php
@@ -803,7 +803,6 @@ HELP;
 
         $functions_blacklist = array(
             '@^mysqli?_\.+@'              => 'Use waModel instead',
-            '@^call_user_func(_array)?$@' => 'Bad practice',
             '@^eregi?(_replace)$@'        => 'Deprecated, use preg/preg_replace',
             '@^spliti?$@'                 => 'Deprecated, use explode',
         );


### PR DESCRIPTION
I disagree that using these functions is **always** bad practice and suggest removing this doubtful limitation. You may want to warn me that they might do somebody harm in certain cases (actually, anything can do harm when used incorrectly), but declaring them as _forbidden_ is a bit too much.
