### PR TITLE
waPlugin: allow to override default control params

### DIFF
--- a/wa-system/plugin/waPlugin.class.php
+++ b/wa-system/plugin/waPlugin.class.php
@@ -284,6 +284,12 @@ class waPlugin
             if (!empty($params['subject']) && !empty($row['subject']) && !in_array($row['subject'], (array)$params['subject'])) {
                 continue;
             }
+            //use custom control params from settings config
+            foreach ($params as $param_key => $param_value) {
+                if (!empty($row[$param_key])) {
+                    unset($params[$param_key]);
+                }
+            }
             $row = array_merge($row, $params);
             $row['value'] = $this->getSettings($name);
             if (!empty($row['control_type'])) {

--- a/wa-system/plugin/waPlugin.class.php
+++ b/wa-system/plugin/waPlugin.class.php
@@ -284,13 +284,7 @@ class waPlugin
             if (!empty($params['subject']) && !empty($row['subject']) && !in_array($row['subject'], (array)$params['subject'])) {
                 continue;
             }
-            //use custom control params from settings config
-            foreach ($params as $param_key => $param_value) {
-                if (!empty($row[$param_key])) {
-                    unset($params[$param_key]);
-                }
-            }
-            $row = array_merge($row, $params);
+            $row = array_merge($params, $row);
             $row['value'] = $this->getSettings($name);
             if (!empty($row['control_type'])) {
                 $controls[$name] = waHtmlControl::getControl($row['control_type'], $name, $row);


### PR DESCRIPTION
For cases when a developer wants to use custom values for `'description_wrapper'`, `'control_wrapper'`, or other default parameters hardcoded in `waPluginsActions::settingsAction()`.