### PR TITLE
waPlugin: allow to override default control params

### DIFF
--- a/wa-system/plugin/waPlugin.class.php
+++ b/wa-system/plugin/waPlugin.class.php
@@ -284,7 +284,7 @@ class waPlugin
             if (!empty($params['subject']) && !empty($row['subject']) && !in_array($row['subject'], (array)$params['subject'])) {
                 continue;
             }
-            $row = array_merge($row, $params);
+            $row = array_merge($params, $row);
             $row['value'] = $this->getSettings($name);
             if (!empty($row['control_type'])) {
                 $controls[$name] = waHtmlControl::getControl($row['control_type'], $name, $row);


### PR DESCRIPTION
For cases when a developer wants to use custom values for 'description_wrapper', 'control_wrapper', or other default parameters hardcoded in waPluginsActions::settingsAction().