### PR TITLE
Mark waRouting::getRouteParam() as deprecated

### DIFF
--- a/wa-system/routing/waRouting.class.php
+++ b/wa-system/routing/waRouting.class.php
@@ -222,7 +222,10 @@ class waRouting
         }
         return $r;
     }
-
+    
+    /**
+     * @deprecated Use getRoute() instead
+     */
     public function getRouteParam($name)
     {
         if ($this->route && isset($this->route[$name])) {


### PR DESCRIPTION
Because its functionality is the same as that of `getRoute()` and it's used only twice in Blog app as far as "official" products are concerned.