### PR TITLE
waHtmlControl: get user control registered status

### DIFF
--- a/wa-system/util/waHtmlControl.class.php
+++ b/wa-system/util/waHtmlControl.class.php
@@ -290,6 +290,17 @@ class waHtmlControl
     }
 
     /**
+     * Returns user control registered status
+     *
+     * @param string $type User control type.
+     * @return boolean Whether specified user control is already registered.
+     */
+    public static function isRegisteredControl($type)
+    {
+        return isset(self::$custom_controls[$type]);
+    }
+
+    /**
      *
      * @param $params
      * @param $name


### PR DESCRIPTION
Instead of
```
static $registered_custom_control;
if (!$registered_custom_control) {
    waHtmlControl::registerControl('CustomControl', array($this, 'registerCustomControl'));
    $registered_custom_control = true;
}
```
I would prefer writing
```
if (!waHtmlControl::isRegisteredControl('CustomControl')) {
    waHtmlControl::registerControl('CustomControl', array($this, 'registerCustomControl'));
}
```