### PR TITLE
Дочерние темы дочерних тем.

### DIFF
--- a/wa-system/view/waView.class.php
+++ b/wa-system/view/waView.class.php
@@ -194,7 +194,8 @@ abstract class waView
         $version = $theme->version(true);
 
         $file = $theme->getFile($template);
-        if ($parent_theme = $theme->parent_theme) {
+	$parent_theme = $theme;
+        while ($parent_theme = $parent_theme->parent_theme) {
             $edition = $theme->edition + $parent_theme->edition;
             if (!empty($file['parent'])) {
                 if ($parent_theme->version($edition) > $version) {
@@ -203,6 +204,7 @@ abstract class waView
                     $version = $theme->version($edition);
                 }
                 $theme = $parent_theme;
+		$file = $parent_theme->getFile($template);
             }
             $this->assign('wa_parent_theme_url', $this->getStaticUrl($parent_theme->url));
             $this->assign('wa_parent_theme_path', $parent_theme->path);

--- a/wa-system/view/waView.class.php
+++ b/wa-system/view/waView.class.php
@@ -194,7 +194,7 @@ abstract class waView
         $version = $theme->version(true);
 
         $file = $theme->getFile($template);
-	$parent_theme = $theme;
+        $parent_theme = $theme;
         while ($parent_theme = $parent_theme->parent_theme) {
             $edition = $theme->edition + $parent_theme->edition;
             if (!empty($file['parent'])) {
@@ -204,7 +204,7 @@ abstract class waView
                     $version = $theme->version($edition);
                 }
                 $theme = $parent_theme;
-		$file = $parent_theme->getFile($template);
+                $file = $parent_theme->getFile($template);
             }
             $this->assign('wa_parent_theme_url', $this->getStaticUrl($parent_theme->url));
             $this->assign('wa_parent_theme_path', $parent_theme->path);


### PR DESCRIPTION
Нужно для произвольной вложенности дочерних тем.
Из реального примера: базовая тема для сайта, от неё тема для магазина, а от неё модификация этой темы.
В модификацию включены только те шаблоны, которые грузятся как $wa_active_theme, а также те, которые нужно переписать. Остальное: чекаут, карточка товара, категория и т.п. грузится из родительской.
У меня это выглядит как-то так http://joxi.ru/823nkJ6IJ3Odem?d=1
Полезно для многовитринных магазинов или, может, временного брендинга.
Обратная совместимость при этом никак не ломается.