### PR TITLE
Fix. PHP Strict Standards: Declaration of blogEmailsubscriptionCli::run()

### DIFF
--- a/wa-apps/blog/plugins/emailsubscription/lib/cli/blogEmailsubscription.cli.php
+++ b/wa-apps/blog/plugins/emailsubscription/lib/cli/blogEmailsubscription.cli.php
@@ -5,7 +5,7 @@
  */
 class blogEmailsubscriptionCli extends waCliController
 {
-    public function run($params = NULL)
+    public function execute()
     {
         $app_settings_model = new waAppSettingsModel();
         $app_settings_model->set(array('blog', 'emailsubscription'), 'last_emailsubscription_cron_time', time());


### PR DESCRIPTION
PHP Strict Standards: Declaration of blogEmailsubscriptionCli::run() should be compatible with waController::run($params = NULL) in .../wa-apps/blog/plugins/emailsubscription/lib/cli/blogEmailsubscription.cli.php on line 7

Проблема описана тут, например
https://support.webasyst.ru/15446/blog-podpiska-po-pochte/