### PR TITLE
Wrapper for `htmlentities` and `htmlspecialchars`

### DIFF
--- a/wa-system/util/waString.class.php
+++ b/wa-system/util/waString.class.php
@@ -15,6 +15,18 @@
 class waString
 {
     /**
+     * Wrapper to simplify htmlentities() and htmlspecialchars usage
+     *
+     * @param string $str
+     * @param int $flags
+     * @return string
+     */
+    public static function escape($str, $flags = ENT_COMPAT | ENT_HTML401)
+    {
+        return htmlentities($str, $flags, 'UTF-8');
+    }
+
+    /**
      * Generate a random UUID (v4)
      * 
      * @see http://www.ietf.org/rfc/rfc4122.txt


### PR DESCRIPTION
Developers very often forget to specify an encoding explicitly when calling functions `htmlspecialchars()` and `htmlentities()`. In addition, the value of the default encoding in these functions depends on the PHP version. The use of default values leads to the appearance of nondescript errors.