### PR TITLE
Add "sugar" for calling app helper

### DIFF
--- a/wa-system/view/waViewHelper.class.php
+++ b/wa-system/view/waViewHelper.class.php
@@ -1237,6 +1237,9 @@ HTML;
 
     public function __get($app)
     {
+        if ($app == 'app') {
+          $app = $this->app_id;
+        }
         if (!isset(self::$helpers[$app])) {
             $wa = wa($this->app_id);
             if ($wa->getConfig()->getApplication() !== $app) {


### PR DESCRIPTION
Smarty не позволяет использовать конструкции вида `$wa->$wa_app->pages() \ $wa->{$wa_app}->pages()`, вызов  `call_user_func \ call_user_func_array` также заблокирован, поэтому во многих темах можно встретить подобные костыли: 
~~~
{if $wa_app == 'shop'}
	{$pages = $wa->shop->pages()}
{elseif $wa_app == 'blog'}
	{$pages = $wa->blog->pages()}
{elseif $wa_app == 'hub'}
	{$pages = $wa->hub->pages()}
{elseif $wa_app == 'photos'}
	{$pages = $wa->photos->pages()}
{else}
	{$pages = $wa->site->pages()}
{/if}
~~~
Данный PR добавляет возможность вызова хэлпера активного приложения через сахар `$wa->app`.