### PR TITLE
Исправлен баг с параметрами страницы

### DIFF
--- a/wa-apps/site/lib/classes/siteViewHelper.class.php
+++ b/wa-apps/site/lib/classes/siteViewHelper.class.php
@@ -78,11 +78,14 @@ class siteViewHelper extends waAppViewHelper
     {
         $page_model = new sitePageModel();
         $page = $page_model->getById($id);
-        $page['content'] = $this->wa->getView()->fetch('string:'.$page['content']);
         
         $page_params_model = new sitePageParamsModel();
         $page += $page_params_model->getById($id);
-
+        
+        $view = $this->wa->getView();
+        $view->assign('page', $page);
+        $page['content'] = ->fetch('string:'.$page['content']);
+        
         return $page;
     }
 }


### PR DESCRIPTION
Необязательный набор параметров вида key=value, к значениям которых можно обращаться в шаблоне page.html или в содержимом текущей страницы как {$page.key}. Каждая пара key=value должна быть указана на отдельной строке