### PR TITLE
Usage and dynamic switching of different db configs

### DIFF
--- a/wa-system/config/waSystemConfig.class.php
+++ b/wa-system/config/waSystemConfig.class.php
@@ -132,6 +132,15 @@ class waSystemConfig
     {
         return $this->getSystemOption($name);
     }
+    
+    public static function database($db = null)
+    {
+        if ($db !== null) {
+            self::$system_options['current_db'] = $db;
+        }
+
+        return !empty(self::$system_options['current_db']) ? self::$system_options['current_db'] : !empty(self::$system_options['use_db']) ? self::$system_options['use_db'] : 'default';
+    }    
 
     public function getFactory($name)
     {

--- a/wa-system/database/waModel.class.php
+++ b/wa-system/database/waModel.class.php
@@ -71,7 +71,7 @@ class waModel
     public function __construct($type = null, $writable = false)
     {
         $this->writable = $writable;
-        $this->type = $type ? $type : 'default';
+        $this->type = $type ? $type : waSystemConfig::database();
         $this->adapter = waDbConnector::getConnection($this->type, $this->writable);
         if ($this->table && !$this->fields) {
             $this->getMetadata();


### PR DESCRIPTION
This patch allow to use any name of database connection config not only `'default'` and switch db connections configs at runtime.

`db.php` -- store any number of db connections:

```php
return array(
    'production' => array(/* MyDB config */),
    'backupdb' => array(/* BackupDB config */),
    'develop' => array(/* development config */),
    'test' => array( /* Test db config */),
);
```

`config.php` -- set any of connection configs as default connection

```php
return array(
    'use_db' => (getenv('WA_ENV') === 'development' ? 'develop' : 'production')
);
```

Switch db connection at runtime:

```php
waSystemConfig::database('test');
```

Get the current db connection config name:

```php
$cfg = waSystemConfig::database();
```

Get db connection config set at startup (useful to switch config back to default):

```php
$cfg = waSystemConfig::getStstemOprion('use_db');
```
