### PR TITLE
Request a complete address in Worldwide Shipping Plugin

### DIFF
--- a/wa-plugins/shipping/worldwide/lib/worldwideShipping.class.php
+++ b/wa-plugins/shipping/worldwide/lib/worldwideShipping.class.php
@@ -141,6 +141,9 @@ class worldwideShipping extends waShipping
     public function requestedAddressFields()
     {
         return array(
+            'street'  => array(),
+            'city'    => array(),
+            'region'  => array(),
             'zip'     => array(),
             'country' => array('cost' => false),
         );


### PR DESCRIPTION
Complete postal address is needed for successful postal delivery. It would be better to allow administrator to choose which address fields should be requested. But this fix is short and can be implemented faster. Rich settings can be implemented later.

Ref: [Complaint in russian support forum](https://support.webasyst.ru/26237/ne-rabotaet-plagin-mezhdunarodnoy-dostavki/)