### PR TITLE
Add expression values to waModel::getWhereByField

### DIFF
--- a/wa-system/database/waModel.class.php
+++ b/wa-system/database/waModel.class.php
@@ -945,6 +945,9 @@ class waModel
             } else {
                 return '1=0';
             }
+        } elseif ($value instanceof waModelExpr) {
+            // Single field, expression value
+            return $prefix.$this->escapeField($field)." ".$this->getFieldValue($field, $value);
         }
 
         // Single field, single value


### PR DESCRIPTION
Add expression values (set as `waModelExpr` object) to `waModel::getWhereByField()`.