### PR TITLE
Changed visibility of waDbQuery::getSQL() to public

### DIFF
--- a/wa-system/database/waDbQuery.class.php
+++ b/wa-system/database/waDbQuery.class.php
@@ -104,7 +104,7 @@ class waDbQuery
         return $this->model->query($sql)->fetchField($field, $seek);
     }
 
-    protected function getSQL()
+    public function getSQL()
     {
         $sql = "SELECT ".$this->select." FROM ".$this->model->getTableName();
         if ($this->where) {


### PR DESCRIPTION
Можно будет строить вложенные запросы.

Используется вот так:
```
$shop_category_products = new waDbQuery(new shopCategoryProductsModel());
$subquery = $shop_category_products->select('product_id')->where('category_id IN (i:ids)', array('ids' => $descendant_ids))->getSQL();
// получаем строку, что-то вроде
// SELECT product_id FROM shop_category_products WHERE category_id IN (1, 2, 3)
// которую можно использовать в подзапросах
$this->where[] = "p.id IN ({$subquery})";
```
Раньше можно было и через строку делать, зато теперь:
- Не нужно делать `implode()` если передаешь параметры в `where`, используется `waDbStatement` + `placeholders`
- Не нужно указывать название таблицы, т.к. оно содержится в модели, которая передается в конструктор
