### PR TITLE
Удаление мусора в editor2.js

### DIFF
--- a/wa-content/js/jquery-wa/editor2.js
+++ b/wa-content/js/jquery-wa/editor2.js
@@ -273,6 +273,30 @@ jQuery.fn.waEditor2 = function () {
                 console.log('imageUploadError', json);
                 alert(json.error);
             },
+            imageDelete: function(e, img) {
+                // skip if option not defined (action URL), example: '?module=pages&action=deleteImage'
+                if (!options.imageDelete) {
+                    return false;
+                }
+                // add translated message in app
+                var msg = options.locales.deleteImageMsg || 'Delete image from server?';
+                if (confirm(msg)) {
+                    var img = $(img);
+                    if (img.prop('tagName') != 'IMG') {
+                        img = img.find('img');
+                    }
+                    $.post(
+                        options.imageDelete,
+                        {file: img.attr('src').replace(wa_url, '')},
+                        function (response) {
+                            if (response.status == 'fail') {
+                                alert(response.errors.join(' '));
+                            }
+                        }, 
+                        'json'
+                    );
+                }
+            },
             keydown: function (e) {
                 // ctrl + s
                 if ((e.which == '115' || e.which == '83' ) && (e.ctrlKey || e.metaKey)) {


### PR DESCRIPTION
После удаления изображений в редакторе, файлы остаются на сервере. А учитывая то, что файл менеджер есть только у "Сайта", то мусора скапливается порядочное количество. Добавил колбек срабатыващий при нажатии кнопки удалить в диалоге редактирования изображения, полностью проблему это не решает, но хотя бы так...
*todo* Осталось cоздать action, удаляющий файлы и добавить в редактор опции imageDelete ('?module=pages&action=deleteImage') и locales.deleteImageMsg ('Delete image from server?').