### PR TITLE
Suppress chmod warnings

### DIFF
--- a/wa-system/log/waLog.class.php
+++ b/wa-system/log/waLog.class.php
@@ -29,7 +29,7 @@ class waLog
         if (!file_exists($file)) {
             waFiles::create(dirname($file), true);
             touch($file);
-            chmod($file, 0666);
+            @chmod($file, 0666);
         } elseif (!is_writable($file)) {
             return false;
         }


### PR DESCRIPTION
`chmod` may produce warnings in some rare cases like "mounted remote NTFS" (running under Windows Subsystem for Linux for ex).