### PR TITLE
Typecast `smallint` as well as `int`, `bigint` and so on

### DIFF
--- a/wa-system/database/waModel.class.php
+++ b/wa-system/database/waModel.class.php
@@ -504,6 +504,7 @@ class waModel
             case 'bigint':
             case 'tinyint':
             case 'int':
+            case 'smallint':
             case 'integer':
                 if (wa_is_int($value)) {
                     return "'".$this->escape($value, 'int')."'";


### PR DESCRIPTION
Sometimes in db tables column type defined as `smallint` regarding to `waModel::getMetadata()` result