### PR TITLE
Fix key mismatch on read and write for memcached adapter

### DIFF
--- a/wa-system/cache/adapters/waMemcachedCacheAdapter.class.php
+++ b/wa-system/cache/adapters/waMemcachedCacheAdapter.class.php
@@ -32,7 +32,7 @@ class waMemcachedCacheAdapter extends waCacheAdapter
 
     public function key($key, $app_id, $group = null)
     {
-        return (isset($this->options['namespace']) ? $this->options['namespace'].'/' : '').parent::key($key, $app_id. $group);
+        return (isset($this->options['namespace']) ? $this->options['namespace'].'/' : '').parent::key($key, $app_id, $group);
     }
 
     public function get($key, $group = null)


### PR DESCRIPTION
Года 3-4 назад смотрел в адаптер мемкешеда, и заметил что он постоянно пишет, и почти никогда не читает. В коде есть несоответствие ключа при чтении и записи. Т.е., пишем с одним ключем, потом читаем уже с другим - в итоге ничего не находим, и снова пишем. Как результат - такое кеширование делает только хуже.

Как минимум в одном месте есть ошибка, в PR есть фикс. 

В общем, PR не для мерджа в ветку, а для того, чтобы обратить внимание на проблему. Лучше детальней взглянуть если у кого-то есть время.