### PR TITLE
Исправлена ошибка waRegexValidator

### DIFF
--- a/wa-system/validator/waEmailValidator.class.php
+++ b/wa-system/validator/waEmailValidator.class.php
@@ -34,10 +34,8 @@ class waEmailValidator extends waRegexValidator
     public function isValid($value)
     {
         $value = is_scalar($value) ? (string)$value : '';
-        if (strlen($value) <= 0) {
-            return false;
-        }
-        if (!preg_match("/^[a-z0-9~@+:\[\]\.-]+$/i", $value)) {
+        
+        if ((strlen($value) > 0) && !preg_match("/^[a-z0-9~@+:\[\]\.-]+$/i", $value)) {
             $idna = new waIdna();
             $value = $idna->encode($value);
         }


### PR DESCRIPTION
После последнего исправления стало игнорировать опцию 'required' при валидации емейлов.
При этом текст ошибки не выводит.
```
$validator = new waEmailValidator(
    array( 'required' => true ),
    array( 'required' => _wp('Email is required') )
);

wa_dump($validator->isValid(''), $validator->getErrors());
```

выводит
```
false
array()
```
То же вернёт и
```
$validator = new waEmailValidator(
    array( 'required' => false )
);
```