### PR TITLE
Add frontend hooks for pages

### DIFF
--- a/wa-system/page/actions/waPage.action.php
+++ b/wa-system/page/actions/waPage.action.php
@@ -74,6 +74,9 @@ class waPageAction extends waViewAction
 
             $this->view->assign('page', $page);
             $this->view->assign('wa_theme_url', $this->getThemeUrl());
+            
+            $this->view->assign('frontend_page', wa($this->getAppId())->event('frontend_page', $page, array('before_content', 'after_content')));
+            
             $page['content'] = $this->renderPage($page);
 
             if ($this->layout) {


### PR DESCRIPTION
Frontend hooks `frontend_page.before_content` and `frontend_page.after_content` for any application that inherits `waPage` for their static pages