### PR TITLE
Backward compatibility with outdated ShopScript

### DIFF
--- a/wa-system/shipping/waShipping.class.php
+++ b/wa-system/shipping/waShipping.class.php
@@ -370,7 +370,16 @@ abstract class waShipping extends waSystemPlugin
      */
     public function getSelectedServiceId()
     {
-        return $this->getPackageProperty('service_variant_id');
+        if(($service_variant_id = $this->getPackageProperty('service_variant_id')) !== null) {
+            return $service_variant_id;
+        }
+        if(($shipping_params = (array)$this->getPackageProperty('shipping_params')) && 
+           ($service_variant_id = ifset($shipping_params, 'service', 'variant_id', null)) 
+           && preg_match("/^\d+\.{$this->key}\./")) {
+            return $service_variant_id;
+        }
+        
+        return null;
     }
 
     /**


### PR DESCRIPTION
Shop-Script 8.0…8.4 умеет передавать информацию о выбранном варианте доставки, но не умеет отдельно передавать его ID. Фикс позволяет извлечь ID варианта доставки, если приложение не передало его отдельным полем, но передало массив с выбранным вариантом.