### PR TITLE
Fixed 'payment_method_data' param of initial post request

### DIFF
--- a/wa-plugins/payment/yandexkassa/lib/yandexkassaPayment.class.php
+++ b/wa-plugins/payment/yandexkassa/lib/yandexkassaPayment.class.php
@@ -284,7 +284,7 @@ class yandexkassaPayment extends waPayment implements waIPayment, waIPaymentCanc
         );
 
         if (!empty($type)) {
-            $data['payment_method'] = array(
+            $data['payment_method_data'] = array(
                 'type' => $type,
             );
         }


### PR DESCRIPTION
Независимо от выбранного в настройках плагина Яндекс.Касса способа оплаты всегда переход происходил на окно выбора способа платежа.

Обнаружилась опечатка в названии параметра
Вместо "payment_method_data" было указано  "payment_method".

Теперь попадаем сразу на выбранный способ оплаты.