### PR TITLE
Fix SmartyException to show unicode message. Update Smarty.class.php

### DIFF
--- a/wa-system/vendors/smarty3/Smarty.class.php
+++ b/wa-system/vendors/smarty3/Smarty.class.php
@@ -1503,7 +1503,7 @@ if (Smarty::$_CHARSET !== 'UTF-8') {
 class SmartyException extends Exception {
     public static $escape = true;
     public function __construct($message) {
-        $this->message = self::$escape ? htmlentities($message) : $message;
+        $this->message = self::$escape ? htmlentities($message, ENT_SUBSTITUTE) : $message;
     }
 }
 


### PR DESCRIPTION
Fix SmartyException to show unicode errors instead of empty strings.