### PR TITLE
Wrong curl option removal 

### DIFF
--- a/wa-apps/blog/plugins/import/lib/classes/blogImportPluginWebasystRemoteTransport.class.php
+++ b/wa-apps/blog/plugins/import/lib/classes/blogImportPluginWebasystRemoteTransport.class.php
@@ -210,7 +210,6 @@ class blogImportPluginWebasystRemoteTransport extends blogImportPluginWebasystTr
             CURLOPT_RETURNTRANSFER    => 1,
             CURLOPT_TIMEOUT           => self::TIMEOUT_SOCKET * 60,
             CURLOPT_CONNECTTIMEOUT    => self::TIMEOUT_SOCKET,
-            CURLE_OPERATION_TIMEOUTED => self::TIMEOUT_SOCKET * 60,
             CURLOPT_BINARYTRANSFER    => true,
             CURLOPT_WRITEFUNCTION     => array(&$this, 'curlWriteHandler'),
             CURLOPT_HEADERFUNCTION    => array(&$this, 'curlHeaderHandler'),

--- a/wa-installer/lib/classes/wainstaller.class.php
+++ b/wa-installer/lib/classes/wainstaller.class.php
@@ -1821,7 +1821,6 @@ class waInstaller
             CURLOPT_RETURNTRANSFER    => 1,
             CURLOPT_TIMEOUT           => self::TIMEOUT_SOCKET * 60,
             CURLOPT_CONNECTTIMEOUT    => self::TIMEOUT_SOCKET,
-            CURLE_OPERATION_TIMEOUTED => self::TIMEOUT_SOCKET * 60,
             CURLOPT_DNS_CACHE_TIMEOUT => 3600,
             CURLOPT_BINARYTRANSFER    => true,
             CURLOPT_WRITEFUNCTION     => array(&$this, 'curlWriteHandler'),

--- a/wa-installer/lib/classes/wainstallerfile.class.php
+++ b/wa-installer/lib/classes/wainstallerfile.class.php
@@ -195,7 +195,6 @@ class waInstallerFile
                 //CURLOPT_VERBOSE           => 1,
                 CURLOPT_TIMEOUT           => self::$timeout,
                 CURLOPT_CONNECTTIMEOUT    => self::$timeout,
-                CURLE_OPERATION_TIMEOUTED => self::$timeout,
                 CURLOPT_DNS_CACHE_TIMEOUT => 3600,
             );
 

--- a/wa-plugins/payment/paypal/lib/paypalPayment.class.php
+++ b/wa-plugins/payment/paypal/lib/paypalPayment.class.php
@@ -439,7 +439,6 @@ class paypalPayment extends waPayment implements waIPayment
         @curl_setopt($ch, CURLOPT_USERAGENT, sprintf('Webasyst %s plugin (%s)', $this->id, $host));
         @curl_setopt($ch, CURLOPT_TIMEOUT, 120);
         @curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 120);
-        @curl_setopt($ch, CURLE_OPERATION_TIMEOUTED, 120);
 
         $response = @curl_exec($ch);
         if (curl_errno($ch) != 0) {

--- a/wa-system/file/waFiles.class.php
+++ b/wa-system/file/waFiles.class.php
@@ -438,7 +438,6 @@ class waFiles
                 CURLOPT_RETURNTRANSFER    => 1,
                 CURLOPT_TIMEOUT           => 10,
                 CURLOPT_CONNECTTIMEOUT    => 10,
-                CURLE_OPERATION_TIMEOUTED => 10,
                 CURLOPT_DNS_CACHE_TIMEOUT => 3600,
                 CURLOPT_BINARYTRANSFER    => true,
                 CURLOPT_WRITEFUNCTION     => array(__CLASS__, 'curlWriteHandler'),

--- a/wa-system/file/waNet.class.php
+++ b/wa-system/file/waNet.class.php
@@ -646,7 +646,6 @@ class waNet
                     CURLOPT_RETURNTRANSFER    => 1,
                     CURLOPT_TIMEOUT           => $this->options['timeout'],
                     CURLOPT_CONNECTTIMEOUT    => $this->options['timeout'],
-                    CURLE_OPERATION_TIMEOUTED => $this->options['timeout'],
                     CURLOPT_DNS_CACHE_TIMEOUT => 3600,
                     CURLOPT_USERAGENT         => $this->user_agent,
                 );


### PR DESCRIPTION
_CURLE_OPERATION_TIMEOUTED_ is an error constant, not a curl option: https://curl.se/libcurl/c/libcurl-errors.html

It was pointless and silent before, but in PHP 8+ it triggers an error:

> PHP Fatal error:  Uncaught ValueError: curl_setopt(): Argument #2 ($option) is not a valid cURL option