### PR TITLE
Fix: `Iterator::rewind()` не должен ничего возвращать

### DIFF
--- a/wa-system/database/waDbResultIterator.class.php
+++ b/wa-system/database/waDbResultIterator.class.php
@@ -90,7 +90,7 @@ class waDbResultIterator implements Iterator
 
     /**
      * Reset key
-     * @return mixed|null
+     * @return void
      */
     public function rewind()
     {
@@ -99,7 +99,6 @@ class waDbResultIterator implements Iterator
         if ($this->count()) {
             $this->seek(0);
         }
-        return $this->current;
     }
 
     /**


### PR DESCRIPTION
В интерфейсе `Iterator` метод `rewind()` заявлен, как возвращающий `void`. 

Просмотрел вызовы этого метода из основного и дочерних классов — возвращаемое значение нигде не используется.