### PR TITLE
Fix: первым аргументом json_decode должна быть строка

### DIFF
--- a/wa-system/request/waRequest.class.php
+++ b/wa-system/request/waRequest.class.php
@@ -633,7 +633,7 @@ class waRequest
         if (!empty($_SERVER['HTTP_X_SCHEME']) && strtolower($_SERVER['HTTP_X_SCHEME']) == 'https') {
             return true;
         }
-        $http_cf_visitor = json_decode(self::server('HTTP_CF_VISITOR'), true);
+        $http_cf_visitor = json_decode((string)self::server('HTTP_CF_VISITOR'), true);
         if (!empty($http_cf_visitor['scheme']) && $http_cf_visitor['scheme'] == 'https') {
             return true;
         }


### PR DESCRIPTION
`waRequest::server()` в случае отсутствия переменной окружения возвращает `NULL`, а для `json_decode` первый аргумент обязательно должен быть строкой. Этот PR исправляет Deprecation Notice при работе под PHP 8.1