### PR TITLE
Fix: возвращаемый тип из waModel::countAll несоответствует документации

### DIFF
--- a/wa-system/database/waModel.class.php
+++ b/wa-system/database/waModel.class.php
@@ -775,9 +775,9 @@ class waModel
      *
      * @return int
      */
-    public function countAll()
+    public function countAll(): int
     {
-        return $this->query("SELECT COUNT(*) FROM ".$this->table)->fetchField();
+        return (int)$this->query("SELECT COUNT(*) FROM ".$this->table)->fetchField();
     }
 
     /**


### PR DESCRIPTION
Несмотря на документацию, сейчас `countAll()` возвращает `string`. Пусть уже работает, как записано в документации!