### PR TITLE
Fix waRequestFile::moveTo();

### DIFF
--- a/wa-system/file/waFiles.class.php
+++ b/wa-system/file/waFiles.class.php
@@ -126,7 +126,12 @@ class waFiles
     public static function move($source_path, $target_path)
     {
         self::create(dirname($target_path));
-        return rename($source_path, $target_path);
+        $result = @rename($source_path, $target_path);
+        if (!$result) {
+            /* Handle rename error between different disks */
+            $result = self::copy($source_path, $target_path) && self::delete($source_path);
+        }
+        return $result;
     }
 
     /**

--- a/wa-system/request/waRequestFile.class.php
+++ b/wa-system/request/waRequestFile.class.php
@@ -103,7 +103,7 @@ class waRequestFile
         if (@is_uploaded_file($this->data['tmp_name'])) {
             return @move_uploaded_file($this->data['tmp_name'], $this->concatFullPath($dir, $name));
         } else {
-            return @rename($this->data['tmp_name'], $this->concatFullPath($dir, $name));
+            return waFiles::move($this->data['tmp_name'], $this->concatFullPath($dir, $name));
         }
     }
 


### PR DESCRIPTION
If `$source_path` and `$target_path` live on different discks (servers), a simple `rename` is not enough.

You need to `copy` a file from one disk to another.