### PR TITLE
Empty string as default value for control_type — fix warning in php 8.1+

### DIFF
--- a/wa-system/plugin/waSystemPlugin.class.php
+++ b/wa-system/plugin/waSystemPlugin.class.php
@@ -585,7 +585,7 @@ abstract class waSystemPlugin
         $settings_config = $this->config();
         foreach ($settings_config as $name => $row) {
             if (!isset($settings[$name])) {
-                switch (preg_replace('@\s.*$@', '', ifset($row['control_type']))) {
+                switch (preg_replace('@\s.*$@', '', ifset($row['control_type'], ''))) {
                     case waHtmlControl::CHECKBOX:
                         $settings[$name] = false;
                         break;


### PR DESCRIPTION
Третьим параметром у preg_replace должна быть строка в любом случае. Если же в settings.php не указан вообще никакой control_type, то сейчас ifset выдаёт null, что приводит к deprecation warning под PHP 8.1+