### PR TITLE
Cast possible null value to a string

### DIFF
--- a/wa-apps/blog/lib/config/blogConfig.class.php
+++ b/wa-apps/blog/lib/config/blogConfig.class.php
@@ -93,7 +93,7 @@ class blogConfig extends waAppConfig
 
         $user = waSystem::getInstance()->getUser();
         $user_id = $user->getId();
-        $type = explode(':',$user->getSettings($app, 'type_items_count'));
+        $type = explode(':', (string)$user->getSettings($app, 'type_items_count'));
         $type = array_filter(array_map('trim',$type),'strlen');
         if (!$type) {
             $type = array('posts','comments_to_my_post','overdue');


### PR DESCRIPTION
На новой, ненастроенной установке `$user->getSettings()` может выдать null, что приводит к deprecation warning под php 8.1+