### PR TITLE
Fix PHP 8.1 deprecation warning

### DIFF
--- a/wa-system/mail/waMailMessage.class.php
+++ b/wa-system/mail/waMailMessage.class.php
@@ -144,8 +144,14 @@ class waMailMessage extends Swift_Message
         return parent::setBody($body, $contentType, $charset);
     }
 
-    protected function prepareBody($body, $charset = null)
+    /**
+     * @param string|null $body
+     * @param string|null $charset
+     * @return string
+     */
+    protected function prepareBody(?string $body, ?string $charset = null): string
     {
+        $body = (string)$body;
         if (preg_match('/\<html|\<head|\<body/im', $body) === 0) {
             if ($charset === null) {
                 $charset = 'utf-8';


### PR DESCRIPTION
Fix deprecation warning `PHP Deprecated:  preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /wa-system/mail/waMailMessage.class.php on line 149`