### PR TITLE
[PHP 8.4] Fix: Curl `CURLOPT_BINARYTRANSFER` deprecated

### DIFF
--- a/wa-apps/blog/plugins/import/lib/classes/blogImportPluginWebasystRemoteTransport.class.php
+++ b/wa-apps/blog/plugins/import/lib/classes/blogImportPluginWebasystRemoteTransport.class.php
@@ -210,7 +210,6 @@ class blogImportPluginWebasystRemoteTransport extends blogImportPluginWebasystTr
             CURLOPT_RETURNTRANSFER    => 1,
             CURLOPT_TIMEOUT           => self::TIMEOUT_SOCKET * 60,
             CURLOPT_CONNECTTIMEOUT    => self::TIMEOUT_SOCKET,
-            CURLOPT_BINARYTRANSFER    => true,
             CURLOPT_WRITEFUNCTION     => array(&$this, 'curlWriteHandler'),
             CURLOPT_HEADERFUNCTION    => array(&$this, 'curlHeaderHandler'),
         );

--- a/wa-installer/lib/classes/wainstaller.class.php
+++ b/wa-installer/lib/classes/wainstaller.class.php
@@ -1846,7 +1846,6 @@ class waInstaller
             CURLOPT_TIMEOUT           => self::TIMEOUT_SOCKET * 60,
             CURLOPT_CONNECTTIMEOUT    => self::TIMEOUT_SOCKET,
             CURLOPT_DNS_CACHE_TIMEOUT => 3600,
-            CURLOPT_BINARYTRANSFER    => true,
             CURLOPT_WRITEFUNCTION     => array(&$this, 'curlWriteHandler'),
             CURLOPT_HEADERFUNCTION    => array(&$this, 'curlHeaderHandler'),
         );

--- a/wa-plugins/payment/qiwi/lib/qiwiPayment.class.php
+++ b/wa-plugins/payment/qiwi/lib/qiwiPayment.class.php
@@ -665,7 +665,6 @@ class qiwiPayment extends waPayment implements waIPaymentCancel, waIPaymentRefun
                 @curl_setopt($ch, CURLOPT_USERPWD, "{$login}:{$this->password}");
 
                 @curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-                @curl_setopt($ch, CURLOPT_BINARYTRANSFER, true);
                 @curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
 
                 if ($query) {

--- a/wa-system/file/waFiles.class.php
+++ b/wa-system/file/waFiles.class.php
@@ -445,7 +445,6 @@ class waFiles
                 CURLOPT_TIMEOUT           => 10,
                 CURLOPT_CONNECTTIMEOUT    => 10,
                 CURLOPT_DNS_CACHE_TIMEOUT => 3600,
-                CURLOPT_BINARYTRANSFER    => true,
                 CURLOPT_WRITEFUNCTION     => array(__CLASS__, 'curlWriteHandler'),
             );
 


### PR DESCRIPTION
The `CURLOPT_BINARYTRANSFER` PHP constant from the Curl extension was no-op since PHP 5.1, and is deprecated in PHP 8.4. This removes the constant usage to avoid the deprecation notice in PHP 8.4 and later.

Because this constant was no-op since PHP 5.1 (circa 2005), this change has no impact.

See:

 - [PHP.Watch - PHP 8.4 - Curl: CURLOPT_BINARYTRANSFER deprecated](https://php.watch/versions/8.4/CURLOPT_BINARYTRANSFER-deprecated)
 - [commit](https://github.com/php/php-src/commit/fc16285538e96ecb35d017231051f83dcbd8b55b)