### PR TITLE
Add default value for mutingErrorHandler

### DIFF
--- a/wa-system/vendors/smarty3/Smarty.class.php
+++ b/wa-system/vendors/smarty3/Smarty.class.php
@@ -1398,7 +1398,7 @@ class Smarty extends Smarty_Internal_TemplateBase {
      * @param integer $errno Error level
      * @return boolean
      */
-    public static function mutingErrorHandler($errno, $errstr, $errfile, $errline, $errcontext)
+    public static function mutingErrorHandler($errno, $errstr, $errfile, $errline, $errcontext = [])
     {
         $_is_muted_directory = false;
 


### PR DESCRIPTION
Fix Smarty error handler parameter compatibility. Since PHP 7.2 fifth parameter is not used anymore.